### PR TITLE
feat: #7 support Native enums

### DIFF
--- a/src/jsonSchemaToZod.ts
+++ b/src/jsonSchemaToZod.ts
@@ -16,9 +16,13 @@ export const jsonSchemaToZod = (
   schema: JSONSchema7,
   name?: string,
   module = true
-): string =>
-  format(
-    `${module ? `import {z} from 'zod'\n\nexport ` : ""}${
+): string => {
+  
+  const ctx = {
+    editingResult: `${module ? `import {z} from 'zod'\n\nexport ` : ""}${
       name ? `const ${name}=` : module ? "default " : "const schema="
-    }${parseSchema(schema)}`
-  );
+    }`
+  }
+  const result = parseSchema(schema, ctx)
+  return format(ctx.editingResult + result);
+}

--- a/src/parsers/parseAllOf.ts
+++ b/src/parsers/parseAllOf.ts
@@ -1,18 +1,19 @@
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { parseSchema, ParseSchemaContext } from "./parseSchema";
 import { half } from "../utils/half";
 
 export function parseAllOf(
-  schema: JSONSchema7 & { allOf: JSONSchema7Definition[] }
+  schema: JSONSchema7 & { allOf: JSONSchema7Definition[] },
+  ctx: ParseSchemaContext
 ): string {
   if (schema.allOf.length === 0) {
     return "z.any()";
   } else if (schema.allOf.length === 1) {
-    return parseSchema(schema.allOf[0]);
+    return parseSchema(schema.allOf[0], ctx);
   } else {
     const [left, right] = half(schema.allOf);
-    return `z.intersection(${parseAllOf({ allOf: left })},${parseAllOf({
+    return `z.intersection(${parseAllOf({ allOf: left }, ctx)},${parseAllOf({
       allOf: right,
-    })})`;
+    }, ctx)})`;
   }
 }

--- a/src/parsers/parseAnyOf.ts
+++ b/src/parsers/parseAnyOf.ts
@@ -2,10 +2,11 @@ import {
   JSONSchema7,
   JSONSchema7Definition
 } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { parseSchema, ParseSchemaContext } from "./parseSchema";
 
 export const parseAnyOf = (
-  schema: JSONSchema7 & { anyOf: JSONSchema7Definition[]; }
+  schema: JSONSchema7 & { anyOf: JSONSchema7Definition[]; },
+  ctx: ParseSchemaContext
 ) => {
-  return `z.union([${schema.anyOf.map(parseSchema)}])`;
+  return `z.union([${schema.anyOf.map(item => parseSchema(item, ctx))}])`;
 };

--- a/src/parsers/parseArray.ts
+++ b/src/parsers/parseArray.ts
@@ -1,12 +1,12 @@
 import { JSONSchema7 } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { parseSchema, ParseSchemaContext } from "./parseSchema";
 
-export const parseArray = (schema: JSONSchema7 & { type: "array" }) => {
+export const parseArray = (schema: JSONSchema7 & { type: "array" }, ctx: ParseSchemaContext) => {
   let r = !schema.items
     ? "z.array(z.any())"
     : Array.isArray(schema.items)
-    ? `z.tuple([${schema.items.map(parseSchema)}])`
-    : `z.array(${parseSchema(schema.items)})`;
+    ? `z.tuple([${schema.items.map((item) => parseSchema(item, ctx))}])`
+    : `z.array(${parseSchema(schema.items, ctx)})`;
   if (typeof schema.minItems === "number") r += `.min(${schema.minItems})`;
   if (typeof schema.maxItems === "number") r += `.max(${schema.maxItems})`;
   return r;

--- a/src/parsers/parseEnum.ts
+++ b/src/parsers/parseEnum.ts
@@ -1,8 +1,23 @@
 import { JSONSchema7, JSONSchema7Type } from "json-schema";
+import { ParseSchemaContext } from "./parseSchema";
 
 export const parseEnum = (
-  schema: JSONSchema7 & { enum: JSONSchema7Type[] | JSONSchema7Type }
+  schema: JSONSchema7 & { enum: JSONSchema7Type[] | JSONSchema7Type },
+  ctx: ParseSchemaContext
 ) => {
+  const needNativeNum = !!schema.enum.find(item => typeof item === 'number' )
+  if (needNativeNum && Array.isArray(schema.enum)) {
+    const addType = `
+const ${ctx.currentPropertyKey} = {
+  ${schema.enum.map((item) => `NUMBER_${item}: ${item}`)},
+} as const;\n\n`
+    if (ctx.editingResult.slice(0, 6) === 'import') {
+      ctx.editingResult = ctx.editingResult.replace(`import {z} from 'zod'\n\n`, `import {z} from 'zod'\n\n${addType}`)
+    } else {
+      ctx.editingResult = addType + ctx.editingResult
+    }
+    return `z.nativeEnum(${ctx.currentPropertyKey})`
+  }
   return Array.isArray(schema.enum)
     ? `z.enum([${schema.enum.map((x: any) => JSON.stringify(x))}])`
     : `z.literal(${JSON.stringify(schema.enum)})`;

--- a/src/parsers/parseIfThenElse.ts
+++ b/src/parsers/parseIfThenElse.ts
@@ -1,16 +1,17 @@
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { parseSchema, ParseSchemaContext } from "./parseSchema";
 
 export const parseIfThenElse = (
   schema: JSONSchema7 & {
     if: JSONSchema7Definition;
     then: JSONSchema7Definition;
     else: JSONSchema7Definition;
-  }
+  },
+  ctx: ParseSchemaContext
 ): string => {
-  const $if = parseSchema(schema.if);
-  const $then = parseSchema(schema.then);
-  const $else = parseSchema(schema.else);
+  const $if = parseSchema(schema.if, ctx);
+  const $then = parseSchema(schema.then, ctx);
+  const $else = parseSchema(schema.else, ctx);
   return `z.union([${$then},${$else}]).superRefine((value,ctx) => {
   const result = ${$if}.safeParse(value).success
     ? ${$then}.safeParse(value)

--- a/src/parsers/parseMultipleType.ts
+++ b/src/parsers/parseMultipleType.ts
@@ -1,10 +1,11 @@
 import { JSONSchema7, JSONSchema7TypeName } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { parseSchema, ParseSchemaContext } from "./parseSchema";
 
 export const parseMultipleType = (
-  schema: JSONSchema7 & { type: JSONSchema7TypeName[] }
+  schema: JSONSchema7 & { type: JSONSchema7TypeName[] },
+  ctx: ParseSchemaContext
 ) => {
   return `z.union([${schema.type.map((type) =>
-    parseSchema({ ...schema, type })
+    parseSchema({ ...schema, type }, ctx)
   )}])`;
 };

--- a/src/parsers/parseObject.ts
+++ b/src/parsers/parseObject.ts
@@ -1,26 +1,28 @@
 import { JSONSchema7 } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { parseSchema, ParseSchemaContext } from "./parseSchema";
 
 const requiredFlag = ""; //".required()"
 const defaultAdditionalFlag = ""; //".strip()"
 
-export const parseObject = (schema: JSONSchema7 & { type: "object" }) => {
+export const parseObject = (schema: JSONSchema7 & { type: "object" }, ctx: ParseSchemaContext) => {
   return !schema.properties
     ? typeof schema.additionalProperties === "object"
-      ? `z.record(${parseSchema(schema.additionalProperties)})`
+      ? `z.record(${parseSchema(schema.additionalProperties, ctx)})`
       : "z.object({}).catchall(z.any())"
     : `z.object({${Object.entries(schema?.properties ?? {}).map(
-        ([k, v]) =>
-          `${JSON.stringify(k)}:${parseSchema(v)}${
+        ([k, v]) => {
+          ctx.currentPropertyKey = k;
+          return `${JSON.stringify(k)}:${parseSchema(v, ctx)}${
             schema.required?.includes(k) ? requiredFlag : ".optional()"
           }`
+        }
       )}})${
         schema.additionalProperties === true
           ? ".catchall(z.any())"
           : schema.additionalProperties === false
           ? ".strict()"
           : typeof schema.additionalProperties === "object"
-          ? `.catchall(${parseSchema(schema.additionalProperties)})`
+          ? `.catchall(${parseSchema(schema.additionalProperties, ctx)})`
           : defaultAdditionalFlag
       }`;
 };

--- a/src/parsers/parseOneOf.ts
+++ b/src/parsers/parseOneOf.ts
@@ -1,11 +1,12 @@
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { parseSchema, ParseSchemaContext } from "./parseSchema";
 
 export const parseOneOf = (
-  schema: JSONSchema7 & { oneOf: JSONSchema7Definition[] }
+  schema: JSONSchema7 & { oneOf: JSONSchema7Definition[] },
+  ctx: ParseSchemaContext
 ) => {
   return `z.any().superRefine((x, ctx) => {
-    const schemas = [${schema.oneOf.map(parseSchema)}];
+    const schemas = [${schema.oneOf.map((item) => parseSchema(item, ctx))}];
     const errors = schemas.reduce(
       (errors: z.ZodError[], schema) =>
         ((result) => ("error" in result ? [...errors, result.error] : errors))(

--- a/src/parsers/parseSchema.ts
+++ b/src/parsers/parseSchema.ts
@@ -20,9 +20,14 @@ import {
 } from "json-schema";
 import { parseOneOf } from "./parseOneOf";
 
-export const parseSchema = (schema: JSONSchema7 | boolean): string => {
+export interface ParseSchemaContext {
+  editingResult: string
+  currentPropertyKey?: string
+}
+
+export const parseSchema = (schema: JSONSchema7 | boolean, ctx: ParseSchemaContext) => {
   if (typeof schema !== "object") return "z.unknown()";
-  let parsed = selectParser(schema);
+  let parsed = selectParser(schema, ctx);
   parsed = addMeta(schema, parsed);
   return parsed;
 };
@@ -32,23 +37,23 @@ const addMeta = (schema: JSONSchema7, parsed: string): string => {
   return parsed;
 };
 
-const selectParser = (schema: JSONSchema7): string => {
+const selectParser = (schema: JSONSchema7, ctx: ParseSchemaContext): string => {
   if (its.an.object(schema)) {
-    return parseObject(schema);
+    return parseObject(schema, ctx);
   } else if (its.an.array(schema)) {
-    return parseArray(schema);
+    return parseArray(schema, ctx);
   } else if (its.a.multipleType(schema)) {
-    return parseMultipleType(schema);
+    return parseMultipleType(schema, ctx);
   } else if (its.an.anyOf(schema)) {
-    return parseAnyOf(schema);
+    return parseAnyOf(schema, ctx);
   } else if (its.an.allOf(schema)) {
-    return parseAllOf(schema);
+    return parseAllOf(schema, ctx);
   } else if (its.a.oneOf(schema)) {
-    return parseOneOf(schema);
+    return parseOneOf(schema, ctx);
   } else if (its.a.not(schema)) {
     return parseNot(schema);
   } else if (its.an.enum(schema)) {
-    return parseEnum(schema); //<-- needs to come before primitives
+    return parseEnum(schema, ctx); //<-- needs to come before primitives
   } else if (its.a.const(schema)) {
     return parseConst(schema);
   } else if (its.a.primitive(schema, "string")) {
@@ -63,7 +68,7 @@ const selectParser = (schema: JSONSchema7): string => {
   } else if (its.a.primitive(schema, "null")) {
     return parseNull(schema);
   } else if (its.a.conditional(schema)) {
-    return parseIfThenElse(schema);
+    return parseIfThenElse(schema, ctx);
   } else {
     return parseDefault(schema);
   }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -2,6 +2,6 @@ import prettier from "prettier";
 import babelParser from "prettier/parser-babel";
 
 export const format = (source: string): string => prettier.format(source, {
-    parser: "babel",
+    parser: "babel-ts",
     plugins: [babelParser],
   })


### PR DESCRIPTION
#7 

- [x]  I’ve added global context. 
- [x] Support Native enums.

e.g.

input schema
```json
{
  "type": "object",
  "properties": {
    "testType": {
      "type": "number",
      "enum": [
        1,
        2
      ]
    },
    "testTypeArray": {
      "type": "array",
      "items": {
        "type": "number",
        "enum": [
          1,
          2,
          3
        ]          
      }
    }
  }
```
output

```ts
import { z } from "zod";

const testTypeArray = {
  NUMBER_1: 1,
  NUMBER_2: 2,
  NUMBER_3: 3,
} as const;

const testType = {
  NUMBER_1: 1,
  NUMBER_2: 2,
} as const;

export default z.object({
  testType: z.nativeEnum(testType).optional(),
  testTypeArray: z.array(z.nativeEnum(testTypeArray)).optional(),
});
```

### Unsupported
- Not support input same key nested object.
  - I would like to support it in another issue in the future.

