### PR TITLE
🔧 Export 'parseSchema' function and fix the example result in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,12 +38,22 @@ const myObject = {
 };
 
 const result = jsonSchemaToZod(myObject);
-
 console.log(result);
+
+const zodSchema = parseSchema(myObject);
+console.log(zodSchema);
 ```
 
 ### Expected output:
 
 ```
-const schema = z.object({hello: z.string()});
+import { z } from "zod";
+
+export default z.object({ hello: z.string().optional() });
+```
+
+and
+
+```
+z.object({hello: z:string().optional()})
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 import { jsonSchemaToZod, jsonSchemaToZodDereffed } from "./jsonSchemaToZod";
 export { jsonSchemaToZod, jsonSchemaToZodDereffed };
+
+import { parseSchema } from "./parsers/parseSchema";
+export { parseSchema };
+
 export default jsonSchemaToZod;


### PR DESCRIPTION
There are some occasions when I need to transform a json-schema to a zod object itself instead of a TypeScript file with additional codes like `import  {z} from "zod"`.
1. I want to parse many json-schema objects to many zod objects, and then write into a single file.

So I hope `parseSchema` can be exported.