### PR TITLE
fix: enum error when there is only one element

### DIFF
--- a/src/parsers/parseEnum.ts
+++ b/src/parsers/parseEnum.ts
@@ -3,9 +3,15 @@ import { JSONSchema7, JSONSchema7Type } from "json-schema";
 export const parseEnum = (
   schema: JSONSchema7 & { enum: JSONSchema7Type[] | JSONSchema7Type }
 ) => {
-  return Array.isArray(schema.enum)
-    ? schema.enum.every((x) => typeof x === "string")
-      ? `z.enum([${schema.enum.map((x) => JSON.stringify(x))}])`
-      : `z.union([${schema.enum.map((x) => `z.literal(${JSON.stringify(x)})`)}])`
-    : `z.literal(${JSON.stringify(schema.enum)})`;
+  if (Array.isArray(schema.enum)) {
+    if (schema.enum.every((x) => typeof x === 'string')) {
+      return `z.enum([${schema.enum.map((x) => JSON.stringify(x))}])`;
+    } else if (schema.enum.length === 1) {  // union does not work when there is only one element
+      return `z.literal(${JSON.stringify(schema.enum[0])})`;
+    } else {
+      return `z.union([${schema.enum.map((x) => `z.literal(${JSON.stringify(x)})`)}])`;
+    }
+  } else {
+    return `z.literal(${JSON.stringify(schema.enum)})`;
+  }
 };


### PR DESCRIPTION
I rewrote the function `parseEnum` because it generates wrong codes in some occasion.

```js
parseSchema({
  enum: [1]
})
```
would be translated into

```js
z.union([z.literal(1)])
```

However, we would get an error:
![image](https://user-images.githubusercontent.com/53432474/199257918-b8782aa4-c63c-4623-808a-4fbd6de00418.png)

It would work if it generate `z.literal(1)` for an array with only one element.