### PR TITLE
Bugfix for falsy defaults

### DIFF
--- a/src/parsers/parseSchema.ts
+++ b/src/parsers/parseSchema.ts
@@ -38,7 +38,7 @@ const addMeta = (schema: JSONSchema7, parsed: string): string => {
 };
 
 const addDefaults = (schema: JSONSchema7, parsed: string): string => {
-  if (schema.default) {
+  if ('default' in schema) {
     parsed += `.default(${JSON.stringify(schema.default)} )`;
   }
   return parsed;

--- a/src/parsers/parseSchema.ts
+++ b/src/parsers/parseSchema.ts
@@ -38,7 +38,7 @@ const addMeta = (schema: JSONSchema7, parsed: string): string => {
 };
 
 const addDefaults = (schema: JSONSchema7, parsed: string): string => {
-  if ('default' in schema) {
+  if (schema.default !== undefined) {
     parsed += `.default(${JSON.stringify(schema.default)} )`;
   }
   return parsed;

--- a/test/jsonSchemaToZod.test.ts
+++ b/test/jsonSchemaToZod.test.ts
@@ -73,4 +73,18 @@ export default z.object({ prop: z.string().default("def") });
 export default z.boolean().default(false);
 `);
   });
+
+  it("will ignore undefined as default", () => {
+    expect(
+      jsonSchemaToZod(
+        {
+          type: "null",
+          default: undefined
+        }
+      )
+    ).toStrictEqual(`import { z } from "zod";
+
+export default z.null();
+`);
+  });
 });

--- a/test/jsonSchemaToZod.test.ts
+++ b/test/jsonSchemaToZod.test.ts
@@ -59,4 +59,18 @@ export default z.string();
 export default z.object({ prop: z.string().default("def") });
 `);
   });
+
+  it("will handle falsy defaults", () => {
+    expect(
+      jsonSchemaToZod(
+        {
+          type: "boolean",
+          default: false
+        }
+      )
+    ).toStrictEqual(`import { z } from "zod";
+
+export default z.boolean().default(false);
+`);
+  });
 });


### PR DESCRIPTION
Don’t really know how that happened but I originally compared default to `undefined` and that worked with falsy values but somehow I hosed that bit of my PR. So here is the fix that makes falsy defaults work properly.