### PR TITLE
feature: Add an option for injecting custom parsers

### DIFF
--- a/src/jsonSchemaToZod.ts
+++ b/src/jsonSchemaToZod.ts
@@ -1,5 +1,5 @@
 import { JSONSchema7 } from "json-schema";
-import { parseSchema } from "./parsers/parseSchema";
+import { Parser, parseSchema } from "./parsers/parseSchema";
 import { format } from "./utils/format";
 import $RefParser from "@apidevtools/json-schema-ref-parser";
 
@@ -7,22 +7,24 @@ export const jsonSchemaToZodDereffed = (
   schema: JSONSchema7,
   name?: string,
   module = true,
-  withoutDefaults = false
+  withoutDefaults = false,
+  customParsers: Record<string, Parser> = {}
 ): Promise<string> =>
   $RefParser
     .dereference(schema)
     .then((schema) =>
-      jsonSchemaToZod(schema as JSONSchema7, name, module, withoutDefaults)
+      jsonSchemaToZod(schema as JSONSchema7, name, module, withoutDefaults, customParsers)
     );
 
 export const jsonSchemaToZod = (
   schema: JSONSchema7,
   name?: string,
   module = true,
-  withoutDefaults = false
+  withoutDefaults = false,
+  customParsers: Record<string, Parser> = {}
 ): string =>
   format(
     `${module ? `import {z} from 'zod'\n\nexport ` : ""}${
       name ? `const ${name}=` : module ? "default " : "const schema="
-    }${parseSchema(schema, withoutDefaults)}`
+    }${parseSchema(schema, withoutDefaults, customParsers)}`
   );

--- a/src/parsers/parseAllOf.ts
+++ b/src/parsers/parseAllOf.ts
@@ -1,15 +1,16 @@
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { Parser, parseSchema } from "./parseSchema";
 import { half } from "../utils/half";
 
 export function parseAllOf(
   schema: JSONSchema7 & { allOf: JSONSchema7Definition[] },
-  withoutDefaults?: boolean
+  withoutDefaults?: boolean,
+  customParsers: Record<string, Parser> = {}
 ): string {
   if (schema.allOf.length === 0) {
     return "z.any()";
   } else if (schema.allOf.length === 1) {
-    return parseSchema(schema.allOf[0], withoutDefaults);
+    return parseSchema(schema.allOf[0], withoutDefaults, customParsers);
   } else {
     const [left, right] = half(schema.allOf);
     return `z.intersection(${parseAllOf(

--- a/src/parsers/parseAnyOf.ts
+++ b/src/parsers/parseAnyOf.ts
@@ -1,15 +1,16 @@
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { Parser, parseSchema } from "./parseSchema";
 
 export const parseAnyOf = (
   schema: JSONSchema7 & { anyOf: JSONSchema7Definition[] },
-  withoutDefaults?: boolean
+  withoutDefaults?: boolean,
+  customParsers: Record<string, Parser> = {}
 ) => {
   return schema.anyOf.length
     ? schema.anyOf.length === 1
-      ? parseSchema(schema.anyOf[0], withoutDefaults)
+      ? parseSchema(schema.anyOf[0], withoutDefaults, customParsers)
       : `z.union([${schema.anyOf.map((schema) =>
-          parseSchema(schema, withoutDefaults)
+          parseSchema(schema, withoutDefaults, customParsers)
         )}])`
     : `z.any()`;
 };

--- a/src/parsers/parseArray.ts
+++ b/src/parsers/parseArray.ts
@@ -1,15 +1,16 @@
 import { JSONSchema7 } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { Parser, parseSchema } from "./parseSchema";
 
 export const parseArray = (
   schema: JSONSchema7 & { type: "array" },
-  withoutDefaults?: boolean
+  withoutDefaults?: boolean,
+  customParsers: Record<string, Parser> = {}
 ) => {
   let r = !schema.items
     ? "z.array(z.any())"
     : Array.isArray(schema.items)
-    ? `z.tuple([${schema.items.map((v) => parseSchema(v, withoutDefaults))}])`
-    : `z.array(${parseSchema(schema.items, withoutDefaults)})`;
+    ? `z.tuple([${schema.items.map((v) => parseSchema(v, withoutDefaults, customParsers))}])`
+    : `z.array(${parseSchema(schema.items, withoutDefaults, customParsers)})`;
   if (typeof schema.minItems === "number") r += `.min(${schema.minItems})`;
   if (typeof schema.maxItems === "number") r += `.max(${schema.maxItems})`;
   return r;

--- a/src/parsers/parseIfThenElse.ts
+++ b/src/parsers/parseIfThenElse.ts
@@ -1,5 +1,5 @@
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { Parser, parseSchema } from "./parseSchema";
 
 export const parseIfThenElse = (
   schema: JSONSchema7 & {
@@ -7,11 +7,12 @@ export const parseIfThenElse = (
     then: JSONSchema7Definition;
     else: JSONSchema7Definition;
   },
-  withoutDefaults?: boolean
+  withoutDefaults?: boolean,
+  customParsers: Record<string, Parser> = {}
 ): string => {
-  const $if = parseSchema(schema.if, withoutDefaults);
-  const $then = parseSchema(schema.then, withoutDefaults);
-  const $else = parseSchema(schema.else, withoutDefaults);
+  const $if = parseSchema(schema.if, withoutDefaults, customParsers);
+  const $then = parseSchema(schema.then, withoutDefaults, customParsers);
+  const $else = parseSchema(schema.else, withoutDefaults, customParsers);
   return `z.union([${$then},${$else}]).superRefine((value,ctx) => {
   const result = ${$if}.safeParse(value).success
     ? ${$then}.safeParse(value)

--- a/src/parsers/parseMultipleType.ts
+++ b/src/parsers/parseMultipleType.ts
@@ -1,11 +1,12 @@
 import { JSONSchema7, JSONSchema7TypeName } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { Parser, parseSchema } from "./parseSchema";
 
 export const parseMultipleType = (
   schema: JSONSchema7 & { type: JSONSchema7TypeName[] },
-  withoutDefaults?: boolean
+  withoutDefaults?: boolean,
+  customParsers: Record<string, Parser> = {}
 ) => {
   return `z.union([${schema.type.map((type) =>
-    parseSchema({ ...schema, type }, withoutDefaults)
+    parseSchema({ ...schema, type }, withoutDefaults, customParsers)
   )}])`;
 };

--- a/src/parsers/parseNot.ts
+++ b/src/parsers/parseNot.ts
@@ -1,12 +1,14 @@
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { Parser, parseSchema } from "./parseSchema";
 
 export const parseNot = (
   schema: JSONSchema7 & { not: JSONSchema7Definition },
-  withoutDefaults?: boolean
+  withoutDefaults?: boolean,
+  customParsers: Record<string, Parser> = {}
 ) => {
   return `z.any().refine((value) => !${parseSchema(
     schema.not,
-    withoutDefaults
+    withoutDefaults,
+    customParsers
   )}.safeParse(value).success, "Invalid input: Should NOT be valid against schema")`;
 };

--- a/src/parsers/parseNullable.ts
+++ b/src/parsers/parseNullable.ts
@@ -1,13 +1,14 @@
 import { JSONSchema7 } from "json-schema";
 import { omit } from "../utils/omit";
-import { parseSchema } from "./parseSchema";
+import { parseSchema, Parser } from "./parseSchema";
 
 /**
  * For compatibility with open api 3.0 nullable
  */
 export const parseNullable = (
   schema: JSONSchema7 & { nullable: true },
-  includeDefaults?: boolean
+  includeDefaults?: boolean,
+  customParsers: Record<string, Parser> = {}
 ) => {
-  return `${parseSchema(omit(schema, "nullable"), includeDefaults)}.nullable()`;
+  return `${parseSchema(omit(schema, "nullable"), includeDefaults, customParsers)}.nullable()`;
 };

--- a/src/parsers/parseOneOf.ts
+++ b/src/parsers/parseOneOf.ts
@@ -1,16 +1,17 @@
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";
-import { parseSchema } from "./parseSchema";
+import { parseSchema, Parser } from "./parseSchema";
 
 export const parseOneOf = (
   schema: JSONSchema7 & { oneOf: JSONSchema7Definition[] },
-  withoutDefaults?: boolean
+  withoutDefaults?: boolean,
+  customParsers: Record<string, Parser> = {}
 ) => {
   return schema.oneOf.length
     ? schema.oneOf.length === 1
-      ? parseSchema(schema.oneOf[0], withoutDefaults)
+      ? parseSchema(schema.oneOf[0], withoutDefaults, customParsers)
       : `z.any().superRefine((x, ctx) => {
     const schemas = [${schema.oneOf.map((schema) =>
-      parseSchema(schema, withoutDefaults)
+      parseSchema(schema, withoutDefaults, customParsers)
     )}];
     const errors = schemas.reduce(
       (errors: z.ZodError[], schema) =>

--- a/test/parsers/parseSchema.test.ts
+++ b/test/parsers/parseSchema.test.ts
@@ -1,0 +1,50 @@
+import { parseSchema } from "../../src/parsers/parseSchema";
+
+describe("parseSchema", () => {
+  it("should parse a number with the default parser", () => {
+    expect(
+      parseSchema(
+        {
+          type: "object",
+          required: ["myRequiredString"],
+          properties: {
+            myNumber: {
+              type: "number",
+            },
+          },
+        },
+        false
+      )
+    ).toStrictEqual(
+      'z.object({"myNumber":z.number().optional()})'
+    );
+
+  });
+  it("parses a number with a custom parser", () => {
+    expect(
+      parseSchema(
+        {
+          type: "object",
+          required: ["myRequiredString"],
+          properties: {
+            myNumber: {
+              type: "number",
+            },
+          },
+        },
+        false,
+        {
+          number: (
+            schema
+          ) => {
+            let r = "z.coerce.number()";
+            return r;
+          }
+        }
+      )
+    ).toStrictEqual(
+      'z.object({"myNumber":z.coerce.number().optional()})'
+    );
+
+  });
+});


### PR DESCRIPTION
Adds an optional `customParsers` param where you can inject your own parser for any type.
This is useful for things like forcing all `number` instances to be parsed with `coerce.number()`