### PR TITLE
fix: using shorthand OR flag for selecting defaults option via cli

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,7 +71,7 @@ if (nameArgumentIndex !== -1) {
 let deref =
   process.argv.indexOf("--deref") !== -1 || process.argv.indexOf("-d") !== -1;
 let withoutDefaults =
-  process.argv.indexOf("--without-defaults") !== -1 &&
+  process.argv.indexOf("--without-defaults") !== -1 ||
   process.argv.indexOf("-wd") !== -1;
 if (targetFilePath) {
   const targetFileDir = dirname(targetFilePath);


### PR DESCRIPTION
As per the documentation `-wd` is the shorthand of `--without-defaults` , the current logic expects both flag `--without-defaults` and shorthand `-wd` to be present in the cli args to ignore the default values in the schema as shown below

> json-schema-to-zod -s person.json -t person.ts --without-defaults -wd

With this fix we can pass `-wd` OR `--without-defaults` to ignore default values in the schema as shown belowl

> json-schema-to-zod -s person.json -t person.ts -wd

OR

>  json-schema-to-zod -s person.json -t person.ts --without-defaults