### PR TITLE
Update parseOneOf.ts

### DIFF
--- a/src/parsers/parseOneOf.ts
+++ b/src/parsers/parseOneOf.ts
@@ -13,7 +13,7 @@ export const parseOneOf = (
       parseSchema(schema, withoutDefaults)
     )}];
     const errors = schemas.reduce(
-      (errors: z.ZodError[], schema) =>
+      (errors, schema) =>
         ((result) => ("error" in result ? [...errors, result.error] : errors))(
           schema.safeParse(x)
         ),


### PR DESCRIPTION
Remove TypeScript types from schema to fix the issue of generating scheme that cannot be invoked directly by new Function.