### PR TITLE
:wrench: Stricter check for schema default presence in parseObject

### DIFF
--- a/src/parsers/parseObject.ts
+++ b/src/parsers/parseObject.ts
@@ -26,11 +26,7 @@ export function parseObject(
           })}`;
 
           const hasDefault =
-            (typeof propSchema === "object" &&
-              propSchema.default !== undefined) ||
-            (typeof objectSchema.default === "object" &&
-              objectSchema.default !== null &&
-              key in objectSchema.default);
+            typeof propSchema === "object" && propSchema.default !== undefined;
 
           const required = Array.isArray(objectSchema.required)
             ? objectSchema.required.includes(key)
@@ -170,15 +166,15 @@ export function parseObject(
     ? patternProperties
       ? properties + patternProperties
       : additionalProperties
-      ? additionalProperties === "z.never()"
-        ? properties + ".strict()"
-        : properties + `.catchall(${additionalProperties})`
-      : properties
+        ? additionalProperties === "z.never()"
+          ? properties + ".strict()"
+          : properties + `.catchall(${additionalProperties})`
+        : properties
     : patternProperties
-    ? patternProperties
-    : additionalProperties
-    ? `z.record(${additionalProperties})`
-    : "z.record(z.any())";
+      ? patternProperties
+      : additionalProperties
+        ? `z.record(${additionalProperties})`
+        : "z.record(z.any())";
 
   if (its.an.anyOf(objectSchema)) {
     output += `.and(${parseAnyOf(


### PR DESCRIPTION
The current implementation for checking default values in JSON schema properties extends beyond the direct property schema (`propSchema`) to include checks within a nested default object (`objectSchema`). This implementation is not aligned with the JSON Schema specification, which recommends defaults be declared directly within the property schema.

```javascript
const hasDefault =
  typeof propSchema === "object" && propSchema.default !== undefined;
```
This change simplifies the `hasDefault` check to focus solely on the direct property schema, enhancing compliance with the JSON Schema specification and how validation libraries handle default values.

https://ajv.js.org/options.html#usedefaults
https://ajv.js.org/guide/modifying-data.html#assigning-defaults