### PR TITLE
Omit defaults for union members when parsing multitype properties

### DIFF
--- a/src/parsers/parseMultipleType.ts
+++ b/src/parsers/parseMultipleType.ts
@@ -6,6 +6,6 @@ export const parseMultipleType = (
   refs: Refs,
 ) => {
   return `z.union([${schema.type
-    .map((type) => parseSchema({ ...schema, type } as any, refs))
+    .map((type) => parseSchema({ ...schema, type } as any, {...refs, withoutDefaults: true}))
     .join(", ")}])`;
 };

--- a/test/index.ts
+++ b/test/index.ts
@@ -12,6 +12,7 @@ import "./parsers/parseNumber.test.js";
 import "./parsers/parseObject.test.js";
 import "./parsers/parseOneOf.test.js";
 import "./parsers/parseSchema.test.js";
+import "./parsers/parseMultipleType.test.js";
 import "./parsers/parseString.test.js";
 import "./utils/cliTools.test.js";
 import "./utils/omit.test.js";

--- a/test/parsers/parseMultipleType.test.ts
+++ b/test/parsers/parseMultipleType.test.ts
@@ -1,0 +1,20 @@
+import { parseSchema } from "../../src/parsers/parseSchema";
+import { suite } from "../suite";
+
+suite("parseMultipleType", (test) => {
+  test("should handle object with multitype properties with default", (assert) => {
+    const schema = {
+      type: "object",
+      properties: {
+        prop: {
+          type: ["string", "null"],
+          default: null,
+        },
+      },
+    };
+    assert(
+      parseSchema(schema, { path: [], seen: new Map() }),
+      `z.object({ "prop": z.union([z.string(), z.null()]).default(null) })`,
+    );
+  });
+});


### PR DESCRIPTION
Added a test for the specific scenario as well.

fixes #119 