### PR TITLE
chore: reorder min/max and regex in string schema generator

### DIFF
--- a/src/parsers/parseString.ts
+++ b/src/parsers/parseString.ts
@@ -32,20 +32,20 @@ export const parseString = (schema: JsonSchemaObject & { type: "string" }) => {
     }
   });
 
-  r += withMessage(schema, "pattern", ({ json }) => [
-    `.regex(new RegExp(${json})`,
-    ", ",
-    ")",
-  ]);
-
   r += withMessage(schema, "minLength", ({ json }) => [
     `.min(${json}`,
     ", ",
     ")",
   ]);
-
+  
   r += withMessage(schema, "maxLength", ({ json }) => [
     `.max(${json}`,
+    ", ",
+    ")",
+  ]);
+  
+  r += withMessage(schema, "pattern", ({ json }) => [
+    `.regex(new RegExp(${json})`,
     ", ",
     ")",
   ]);


### PR DESCRIPTION
## What

In the JSON-Schema-to-Zod generator, calls to `.regex()` for string fields
were emitted *before* `.min()`/`.max()`. As a result:

1. If the user enters fewer than the minimum characters, they get a
   “pattern mismatch” error instead of “too short”.
2. Only when the length requirement is satisfied does the regex check fire.

This PR swaps the order so that:

1. `.min()` and `.max()` run first and surface length errors.
2. `.regex()` runs afterwards, showing pattern errors only on valid-length strings.

## Why

- Improves UX: users see the most relevant validation message first.
- Aligns behavior with Zod’s recommendation: length checks before pattern checks.

## Changes

- In `src/parsers/parseString.ts`, moved the block that generates `.regex()`
  to after the blocks for `.minLength`/`.maxLength`.
