### PR TITLE
Adds unique constraint to parseArray 

### DIFF
--- a/src/parsers/parseArray.ts
+++ b/src/parsers/parseArray.ts
@@ -30,6 +30,14 @@ export const parseArray = (
     ", ",
     ")",
   ]);
-
+  
+  if (schema.uniqueItems === true) {
+    r += withMessage(schema, "uniqueItems", () => [
+      ".unique(",
+      "",
+      ")",
+    ]);
+  }
+  
   return r;
 };

--- a/test/parsers/parseArray.test.ts
+++ b/test/parsers/parseArray.test.ts
@@ -52,4 +52,20 @@ suite("parseArray", (test) => {
       "z.array(z.string()).max(2)",
     );
   });
+  
+  test("should add unique for uniqueItems", (assert) => {
+    assert(
+      parseArray(
+        {
+          type: 'array',
+          uniqueItems: true,
+          items: {
+            type: 'string'
+          }
+        },
+        { path: [], seen: new Map() },
+      ),
+      "z.array(z.string()).unique()",
+    );
+  });
 })


### PR DESCRIPTION
Fixes https://github.com/StefanTerdell/json-schema-to-zod/issues/117 

Added a test for this case and renamed parseArray.test.js to parseArray.test.ts as it seemed to be misnamed. LMK if I did everything correctly :)